### PR TITLE
Sections for Properties File

### DIFF
--- a/src/properties.js
+++ b/src/properties.js
@@ -222,8 +222,24 @@ Properties.prototype.get = function (key, defaultValue){
 	return k !== undefined ? k.value : defaultValue;
 };
 
+Properties.prototype.getS = function (section, key, defaultValue){
+	var s = this._sections[section];
+	if (s === undefined){
+		return defaultValue;
+	}
+	var k = s[key];
+	return k !== undefined ? k.value : defaultValue;
+};
+
 Properties.prototype.keys = function (){
 	return Object.keys (this._keys);
+};
+
+Properties.prototype.sectionKeys = function (section){
+	if (typeof this._sections[section] === "undefined"){
+		return Object.keys (this._sections);
+	}
+	return Object.keys (this._sections[section]);
 };
 
 Properties.prototype.load = function (fileName, cb){

--- a/src/properties.js
+++ b/src/properties.js
@@ -202,13 +202,15 @@ PropertyReader.prototype.parse = function (c){
 				this._readKeyValue (this._line);
 			}
 			this._line = "";
+
+			this._isSectionLine = false;
 		}
 	}
 };
 
 var Properties = function (){
 	this._keys = {};
-	this._sections = null;
+	this._sections = {};
 	this._currentSection = null;
 };
 

--- a/src/properties.js
+++ b/src/properties.js
@@ -284,6 +284,17 @@ Properties.prototype.set = function (key, value, comment){
 	return this;
 };
 
+Properties.prototype.setS = function (section, key, value, comment){
+	if (typeof this._sections[section] === "undefined"){
+		this._sections[section] = {};
+	}
+	this._sections[section][key] = {
+		value: value ? value.toString () : value,
+		comment: comment
+	};
+	return this;
+};
+
 var convert = function (string, escapeSpace, unicode){
 	var c;
 	var code;

--- a/src/properties.js
+++ b/src/properties.js
@@ -404,6 +404,20 @@ Properties.prototype.store = function (fileName, unicode, headerComment, cb){
 			convert (k.value, false, unicode)).newLine ();
 	}
 	
+	for (var s in this._sections){
+		if (this._sections.hasOwnProperty(s)){
+			bw.write ("[" + convert (s, true, unicode) + "]").newLine ();
+			for (var p in this._sections[s]){
+				k = this._sections[s][p];
+				if (k.comment){
+					bw.write (Properties.COMMENT + k.comment).newLine ();
+				}
+				bw.write (convert (p, true, unicode) + Properties.SEPARATOR +
+					convert (k.value, false, unicode)).newLine ();
+			}
+		}
+	}
+
 	bw.close (function (){
 		if (cb) cb (null);
 	});


### PR DESCRIPTION
I started using your project (thanks for making it) but needed sections (http://en.wikipedia.org/wiki/INI_file#Sections). I have implemented and tested it (apart from saving to a file which I do not need and hence have not tested). It treats any pairs before a section header as part of the _keys and ones after as part of _sections. Meaning it will not break existing code that uses this library. Sections are delimited as follows:

```
[section]

key=value

[section2]

key=value
```
