### PR TITLE
Make type casting configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,17 @@ Options:
   ```
 - __strict__ - _Boolean_  
   This option can be used with the `comments` and `separators` options. If true, __only__ the tokens specified in these options are used to parse comments and separators.
+- __casting__ - _Object_  
+  By default, property values will be cast to their JavaScript type equivalent. It is possible to disable this behaviour per type:
+```javascript
+casting: {
+    nulls: false,
+    undefineds: false,
+    booleans: false,
+    numbers: false
+}
+```
+For example, if your property values may contain numbers in octal, hexadecimal or exponential notation, think carefully about their range and their subsequent usage, or the automatic casting might surprise you.
 - __sections__ - _Boolean_  
   Parses INI sections. Read the [INI](#ini) section for further details.
 - __namespaces__ - _Boolean_  

--- a/README.md
+++ b/README.md
@@ -385,15 +385,17 @@ Options:
   This option can be used with the `comments` and `separators` options. If true, __only__ the tokens specified in these options are used to parse comments and separators.
 - __casting__ - _Object_  
   By default, property values will be cast to their JavaScript type equivalent. It is possible to disable this behaviour per type:
-```javascript
-casting: {
-    nulls: false,
-    undefineds: false,
-    booleans: false,
-    numbers: false
-}
-```
-For example, if your property values may contain numbers in octal, hexadecimal or exponential notation, think carefully about their range and their subsequent usage, or the automatic casting might surprise you.
+
+  ```javascript
+  casting: {
+      nulls: false,
+      undefineds: false,
+      booleans: false,
+      numbers: false
+  }
+  ```
+
+  For example, if your property values may contain numbers in octal, hexadecimal or exponential notation, think carefully about their range and their subsequent usage, or the automatic casting might surprise you.
 - __sections__ - _Boolean_  
   Parses INI sections. Read the [INI](#ini) section for further details.
 - __namespaces__ - _Boolean_  

--- a/lib/read.js
+++ b/lib/read.js
@@ -3,17 +3,29 @@
 var fs = require ("fs");
 var path = require ("path");
 var parse = require ("./parse");
+var merge = require('deepmerge');
 
 var INCLUDE_KEY = "include";
 var INDEX_FILE = "index.properties";
+var CASTING_DEFAULTS = {
+  nulls: true,
+  undefineds: true,
+  booleans: true,
+  numbers: true
+};
 
-var cast = function (value){
-  if (value === null || value === "null") return null;
-  if (value === "undefined") return undefined;
-  if (value === "true") return true;
-  if (value === "false") return false;
-  var v = Number (value);
-  return isNaN (v) ? value : v;
+var cast = function (value, options){
+  if (options.nulls) { if (value === null || value === "null") return null; }
+  if (options.undefineds) { if (value === "undefined") return undefined; }
+  if (options.booleans) {
+    if (value === "true") return true;
+    if (value === "false") return false;
+  }
+  if (options.numbers) {
+    var v = Number (value);
+    return isNaN (v) ? value : v;
+  }
+  return value;
 };
 
 var expand = function  (o, str, options, cb){
@@ -365,7 +377,7 @@ var build = function (data, options, dirname, cb){
             function (error, value){
           if (error) return abort (error);
           
-          line (key, cast (value || null));
+          line (key, cast (value || null, options._casting));
         });
       });
     };
@@ -381,7 +393,7 @@ var build = function (data, options, dirname, cb){
     }
   }else{
     handlers.line = function (key, value){
-      line (key, cast (value || null));
+      line (key, cast (value || null, options._casting));
     };
     
     if (options.sections){
@@ -436,6 +448,7 @@ module.exports = function (data, options, cb){
   options = options || {};
   options._strict = options.strict && (options.comments || options.separators);
   options._vars = options.vars || {};
+  options._casting = merge(CASTING_DEFAULTS, options.casting);
   
   var comments = options.comments || [];
   if (!Array.isArray (comments)) comments = [comments];

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   "engines": {
     "node": ">=0.10"
   },
+  "dependencies": {
+    "deepmerge": "^0.2.7"
+  },
   "devDependencies": {
-    "deepmerge": "^0.2.7",
     "ini": "1.1.x",
     "js-yaml": "2.1.x",
     "speedy": "*"

--- a/package.json
+++ b/package.json
@@ -2,16 +2,23 @@
   "name": "properties",
   "version": "1.2.1",
   "description": ".properties parser/stringifier",
-  "keywords": ["properties", "ini", "parser", "stringifier", "config"],
+  "keywords": [
+    "properties",
+    "ini",
+    "parser",
+    "stringifier",
+    "config"
+  ],
   "author": "Gabriel Llamas <gagle@outlook.com>",
   "repository": "git://github.com/gagle/node-properties.git",
   "engines": {
     "node": ">=0.10"
   },
   "devDependencies": {
+    "deepmerge": "^0.2.7",
     "ini": "1.1.x",
-    "speedy": "*",
-    "js-yaml": "2.1.x"
+    "js-yaml": "2.1.x",
+    "speedy": "*"
   },
   "scripts": {
     "test": "node test/parse && node test/stringify"

--- a/test/parse.js
+++ b/test/parse.js
@@ -43,11 +43,6 @@ var tests = {
         a19: "É",
         "←": "→",
         "→": "→",
-        a20: true,
-        a21: false,
-        a22: 123,
-        a23: null,
-        a24: undefined,
         "[a]": null
       });
       
@@ -592,6 +587,50 @@ var tests = {
       
       done ();
     });
+  },
+  "cast values according to defaults": function(done) {
+    var options = { path: true };
+
+    properties.parse ("types", options,
+      function (error, p){
+        assert.ifError (error);
+
+        assert.deepEqual (p, {
+          a1: true,
+          a2: false,
+          a3: 123,
+          a4: null,
+          a5: undefined,
+          a6: 123,
+          a7: 291,
+          a8: 1230
+        });
+
+        done ();
+      }
+    );
+  },
+  "cast values according to options": function(done) {
+    var options = { path: true, casting: { nulls: false, undefineds: false, booleans: false, numbers: false } };
+
+    properties.parse ("types", options,
+      function (error, p){
+        assert.ifError (error);
+
+        assert.deepEqual (p, {
+          a1: 'true',
+          a2: 'false',
+          a3: '123',
+          a4: 'null',
+          a5: 'undefined',
+          a6: '0123',
+          a7: '0x123',
+          a8: '123e1'
+        });
+
+        done ();
+      }
+    );
   }
 };
 

--- a/test/properties
+++ b/test/properties
@@ -45,12 +45,5 @@ a19		\u00c9
 92=\u\21\
 92
 
-#Type conversion
-a20 true
-a21 false
-a22 123
-a23 null
-a24 undefined
-
 #No sections
 [a]

--- a/test/types
+++ b/test/types
@@ -1,0 +1,9 @@
+#Type conversion
+a1 true
+a2 false
+a3 123
+a4 null
+a5 undefined
+a6 0123
+a7 0x123
+a8 123e1


### PR DESCRIPTION
I can see how the automatic casting of property values to JavaScript types might come in useful, but sometimes you really just want the literal value.

For my use case: I am reading a properties file containing mappings between file names and their SHA-1 hashes, truncated to 8 characters. Some of those hashes might look like numbers in exponential notation, say '90e02100', in which case having them cast to a Number is definitely not a good thing.

The same could be argued for numbers in octal or hex notation, I guess.

So, as per subject, I made this configurable, added the relevant tests and updated the Readme.
