### PR TITLE
Add support for tolerant substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Options:
   Parses dot separated keys as JavaScript objects. Look at the [namespaces](#namespaces) section for further details.
 - __variables__ - _Boolean_  
   Allows you to read the value of a key while the file is being parsed. Look at the [variables](#variables) section for further details.
+- __tolerant_substitution__ - _Boolean_  
+  This option can be used with the `variables` option. if true, it allows properties to be partially parsed instead of returning an error when a variable is not set.
 - __vars__ - _Boolean_  
   External variables can be passed to the file if the variables option is enabled. Look at the [variables](#variables) section for further details.
 - __include__ - _Boolean_  

--- a/lib/read.js
+++ b/lib/read.js
@@ -49,10 +49,10 @@ var expand = function  (o, str, options, cb){
       }else if (c === "}"){
         holder = section !== null ? searchValue (o, section, true) : o;
         if (!holder){
-          if(options.tolerant_substitution) {
+          if (options.tolerant_substitution){
             holder = o;
-          } else{
-            return cb (new Error ("The section \"" + section + "\" does not " +
+          }else{
+            return cb (new Error("The section \"" + section + "\" does not " +
               "exist"));
           }
         }
@@ -65,10 +65,10 @@ var expand = function  (o, str, options, cb){
               : options._vars[key]
           
           if (v === undefined){
-            if(options.tolerant_substitution) {
+            if (options.tolerant_substitution){
               return cb (null, str);
-            } else {
-              return cb(new Error("The property \"" + key + "\" does not " +
+            }else{
+              return cb (new Error("The property \"" + key + "\" does not " +
                 "exist"));
             }
           }
@@ -130,7 +130,7 @@ var namespaceKey = function (o, key, value){
   o[n[n.length - 1]] = value;
 };
 
-var splitByDotWithVariables = function(section) {
+var splitByDotWithVariables = function (section){
   var splitNamespaces = [];
   var previousChar;
   var currentChar;
@@ -139,19 +139,19 @@ var splitByDotWithVariables = function(section) {
   var closedVariables = 0;
   section = "." + section + ".";
 
-  for (var i = 0; i < section.length; i++) {
+  for (var i=0; i<section.length; i++){
     currentChar = section[i];
-    if (previousChar === "$" && currentChar === "{") {
+    if (previousChar === "$" && currentChar === "{"){
       openedVariables++;
-    } else if (currentChar === "}") {
+    }else if (currentChar === "}"){
       closedVariables++;
-      if (openedVariables == closedVariables) {
+      if (openedVariables == closedVariables){
         openedVariables = 0;
         closedVariables = 0;
-        splitNamespaces.push(section.substring(startingDotPointer +1, i + 1));
+        splitNamespaces.push(section.substring(startingDotPointer + 1, i + 1));
       }
-    } else if (currentChar === "." && openedVariables === 0) {
-      if (startingDotPointer >= 0 && previousChar !== "}") {
+    }else if (currentChar === "." && openedVariables === 0){
+      if (startingDotPointer >= 0 && previousChar !== "}"){
         splitNamespaces.push(section.substring(startingDotPointer + 1, i));
       }
       startingDotPointer = i;
@@ -159,25 +159,26 @@ var splitByDotWithVariables = function(section) {
     previousChar = currentChar;
   }
   return splitNamespaces;
-}
+};
 
-var namespaceSection = function(o, section, tolerant_substitution){
+var namespaceSection = function (o, section, tolerant_substitution){
 
   var n;
   if (tolerant_substitution){
     n = splitByDotWithVariables(section);
-  } else{
+  }else{
     n = section.split(".");
   }
 
   var str;
-  for (var i = 0; i < n.length; i++){
+
+  for (var i=0; i<n.length; i++){
     str = n[i];
     if (o[str] === undefined){
       o[str] = {};
-    } else if (typeof o[str] !== "object"){
-      throw new Error("Invalid namespace chain in the section name '" +
-        section + "' ('" + str + "' has already a value)");
+    }else if (typeof o[str] !== "object"){
+      throw new Error ("Invalid namespace chain in the section name '" +
+          section + "' ('" + str + "' has already a value)");
     }
     o = o[str];
   }

--- a/lib/read.js
+++ b/lib/read.js
@@ -131,13 +131,14 @@ var namespaceKey = function (o, key, value){
 };
 
 var splitByDotWithVariables = function(section) {
-  var splittedNamespaces = [];
+  var splitNamespaces = [];
   var previousChar;
   var currentChar;
-  var startingDotpointer = -1;
+  var startingDotPointer = -1;
   var openedVariables = 0;
   var closedVariables = 0;
   section = "." + section + ".";
+
   for (var i = 0; i < section.length; i++) {
     currentChar = section[i];
     if (previousChar === "$" && currentChar === "{") {
@@ -147,35 +148,40 @@ var splitByDotWithVariables = function(section) {
       if (openedVariables == closedVariables) {
         openedVariables = 0;
         closedVariables = 0;
-        splittedNamespaces.push(section.substring(startingDotpointer +1, i + 1));
+        splitNamespaces.push(section.substring(startingDotPointer +1, i + 1));
       }
     } else if (currentChar === "." && openedVariables === 0) {
-      if (startingDotpointer >= 0 && previousChar !== "}") {
-        splittedNamespaces.push(section.substring(startingDotpointer + 1, i));
+      if (startingDotPointer >= 0 && previousChar !== "}") {
+        splitNamespaces.push(section.substring(startingDotPointer + 1, i));
       }
-      startingDotpointer = i;
+      startingDotPointer = i;
     }
     previousChar = currentChar;
   }
-  return splittedNamespaces;
+  return splitNamespaces;
 }
-var namespaceSection = function (o, section){
 
+var namespaceSection = function(o, section, tolerant_substitution){
 
-  var n = splitByDotWithVariables(section);
+  var n;
+  if (tolerant_substitution){
+    n = splitByDotWithVariables(section);
+  } else{
+    n = section.split(".");
+  }
+
   var str;
-
-  for (var i=0; i<n.length; i++){
+  for (var i = 0; i < n.length; i++){
     str = n[i];
-    if (o[str] === undefined) {
+    if (o[str] === undefined){
       o[str] = {};
-    }else if (typeof o[str] !== "object"){
-      throw new Error ("Invalid namespace chain in the section name '" +
-          section + "' ('" + str + "' has already a value)");
+    } else if (typeof o[str] !== "object"){
+      throw new Error("Invalid namespace chain in the section name '" +
+        section + "' ('" + str + "' has already a value)");
     }
     o = o[str];
   }
-  
+
   return o;
 };
 
@@ -367,7 +373,7 @@ var build = function (data, options, dirname, cb){
         if (add){
           if (options.namespaces){
             try{
-              currentSection = namespaceSection (n, section);
+              currentSection = namespaceSection (n, section, options.tolerant_substitution);
             }catch (error){
               abort (error);
             }
@@ -383,7 +389,7 @@ var build = function (data, options, dirname, cb){
         currentSectionStr = section;
         if (options.namespaces){
           try{
-            currentSection = namespaceSection (n, section);
+            currentSection = namespaceSection (n, section, options.tolerant_substitution);
           }catch (error){
             abort (error);
           }

--- a/lib/read.js
+++ b/lib/read.js
@@ -49,8 +49,12 @@ var expand = function  (o, str, options, cb){
       }else if (c === "}"){
         holder = section !== null ? searchValue (o, section, true) : o;
         if (!holder){
-          return cb (new Error ("The section \"" + section + "\" does not " +
+          if(options.tolerant_substitution) {
+            holder = o;
+          } else{
+            return cb (new Error ("The section \"" + section + "\" does not " +
               "exist"));
+          }
         }
         
         v = options.namespaces ? searchValue (holder, key) : holder[key];
@@ -61,8 +65,12 @@ var expand = function  (o, str, options, cb){
               : options._vars[key]
           
           if (v === undefined){
-            return cb (new Error ("The property \"" + key + "\" does not " +
+            if(options.tolerant_substitution) {
+              return cb (null, str);
+            } else {
+              return cb(new Error("The property \"" + key + "\" does not " +
                 "exist"));
+            }
           }
         }
         
@@ -122,13 +130,44 @@ var namespaceKey = function (o, key, value){
   o[n[n.length - 1]] = value;
 };
 
+var splitByDotWithVariables = function(section) {
+  var splittedNamespaces = [];
+  var previousChar;
+  var currentChar;
+  var startingDotpointer = -1;
+  var openedVariables = 0;
+  var closedVariables = 0;
+  section = "." + section + ".";
+  for (var i = 0; i < section.length; i++) {
+    currentChar = section[i];
+    if (previousChar === "$" && currentChar === "{") {
+      openedVariables++;
+    } else if (currentChar === "}") {
+      closedVariables++;
+      if (openedVariables == closedVariables) {
+        openedVariables = 0;
+        closedVariables = 0;
+        splittedNamespaces.push(section.substring(startingDotpointer +1, i + 1));
+      }
+    } else if (currentChar === "." && openedVariables === 0) {
+      if (startingDotpointer >= 0 && previousChar !== "}") {
+        splittedNamespaces.push(section.substring(startingDotpointer + 1, i));
+      }
+      startingDotpointer = i;
+    }
+    previousChar = currentChar;
+  }
+  return splittedNamespaces;
+}
 var namespaceSection = function (o, section){
-  var n = section.split (".");
+
+
+  var n = splitByDotWithVariables(section);
   var str;
-  
+
   for (var i=0; i<n.length; i++){
     str = n[i];
-    if (o[str] === undefined){
+    if (o[str] === undefined) {
       o[str] = {};
     }else if (typeof o[str] !== "object"){
       throw new Error ("Invalid namespace chain in the section name '" +

--- a/test/parse.js
+++ b/test/parse.js
@@ -350,10 +350,10 @@ var tests = {
       done ();
     });
   },
-  "variables supporting tolerant substitution": function(done) {
+  "variables supporting tolerant substitution": function(done){
     var options = {variables: true, path: true, sections: true, namespaces: true, tolerant_substitution: true};
 
-    properties.parse("variables-tolerant-substitution", options, function(error, p) {
+    properties.parse("variables-tolerant-substitution", options, function(error, p){
       assert.ifError(error);
 
       assert.deepEqual(p, {

--- a/test/parse.js
+++ b/test/parse.js
@@ -350,6 +350,28 @@ var tests = {
       done ();
     });
   },
+  "variables supporting tolerant substitution": function(done) {
+    var options = {variables: true, path: true, sections: true, namespaces: true, tolerant_substitution: true};
+
+    properties.parse("variables-tolerant-substitution", options, function(error, p) {
+      assert.ifError(error);
+
+      assert.deepEqual(p, {
+        "a": 1,
+        "b": 1,
+        "foo": "${bar}",
+        "section": {"c": 3, "d": 3, "e": "${section_foo|bar}"},
+        "s1": {"e2": "ee"},
+        "s${bar}": {"e2": "ee"},
+        "namespace": {"a": {"b": "c"}},
+        "c": {"a": {"b": {"x": 1}, "e": 1}},
+        "${namespace|a.b.bar}": {"a": {"b": {"x": 1}}},
+        "${namespace|a.${h}.bar}": {"afgd": {"bsada": {"${bar}": {"foo": {"bar": "foo"}}}}}
+      });
+
+      done();
+    });
+  },
   "namespaces": function (done){
     var options = { path: true, variables: true, namespaces: true };
     

--- a/test/variables-tolerant-substitution
+++ b/test/variables-tolerant-substitution
@@ -1,0 +1,31 @@
+#simple substitution
+a = 1
+b = ${a}
+foo=${bar}
+
+#section substitution
+[section]
+c = 3
+d = ${section|c}
+e = ${section_foo|bar}
+
+[s${a}]
+e2 = ee
+
+[s${bar}]
+e2 = ee
+
+#namespace substitution
+[namespace]
+a.b c
+
+[${namespace|a.b}.a]
+b.x 1
+
+e ${c.a|b.x}
+
+[${namespace|a.b.bar}.a]
+b.x 1
+
+[${namespace|a.${h}.bar}.afgd.bsada.${bar}.foo]
+bar=foo


### PR DESCRIPTION
node-properties is currently throwing an error when it cannot find a variable. 

Sometimes, we want to keep the placeholders as the application itself or another tool will resolve the placeholders further ahead in the process.

The tolerant_substitution option allows this behavior by partially resolving the properties if it cannot find some properties. 
