### PR TITLE
Write/Stringify: Removed extra whitespace before and after '=' separator

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -35,8 +35,10 @@ module.exports = function (stringifier, options, cb){
   }else{
     options._separator = "=";
   }
-  
-  options._separator = " " + options._separator + " ";
+  // only add spaces if separator is not '=' 
+  if( options._separator != "=" ){ 
+    options._separator = " " + options._separator + " ";
+  }
   
   var data = stringify (stringifier, options);
   


### PR DESCRIPTION
Original parsed properties file had no space before/after '='. We had problems with stringified properties due to extra spaces. Removed automatic space insertion if separator is '='.
