### PR TITLE
close #31 stable number coercion (non breaking impl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ properties.parse ("file", { path: true }, function (error, obj){
 
 #### Functions ####
 
+- [_module_.with(modifiers...) : _module_](#with)
 - [_module_.parse(data[, options][, callback]) : undefined | Object](#parse)
 - [_module_.createStringifier() : Stringifier](#createStringifier)
 - [_module_.stringify(obj[, options][, callback]) : undefined | String](#stringify)
@@ -339,6 +340,23 @@ config.load (function (error, obj){
 ```
 
 Note: You can also use a configuration loader like [seraphim](https://github.com/gagle/node-seraphim).
+
+---
+
+<a name="with"></a>
+___module_.with(modifiers...) : _module___
+
+Apply optional static modifiers to the module context that alter default behaviour or include non-standard logic.  This function returns the module itself so it may be chained.
+
+```javascript
+properties
+  .with("MODIFIER_NAME")
+  .parse({ ... });
+```
+
+Modifiers: 
+
+ - MOD_STABLE_NUMBER_COERCION - when reading properties, asserts that values identified as numerical must also satisfy the condition: `String(Number(x))===String(x)`
 
 ---
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var Stringifier = require ("./stringifier");
 
 module.exports = {
+  with: require ("./with"),
   parse: require ("./read"),
   stringify: require ("./write"),
   createStringifier: function (){

--- a/lib/read.js
+++ b/lib/read.js
@@ -3,6 +3,7 @@
 var fs = require ("fs");
 var path = require ("path");
 var parse = require ("./parse");
+var modifiers = require ("./with").modifiers;
 
 var INCLUDE_KEY = "include";
 var INDEX_FILE = "index.properties";
@@ -13,7 +14,10 @@ var cast = function (value){
   if (value === "true") return true;
   if (value === "false") return false;
   var v = Number (value);
-  return isNaN (v) ? value : v;
+  var isStableNumber = String (v) === value;
+  return isNaN (v) ? value : (
+    modifiers.MOD_STABLE_NUMBER_COERCION && !isStableNumber ? value : v
+  );
 };
 
 var expand = function  (o, str, options, cb){

--- a/lib/with.js
+++ b/lib/with.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var modifiers = {
+  MOD_STABLE_NUMBER_COERCION: false
+};
+
+// @Chainable
+module.exports = function (/** modifiers... */){
+  [].forEach.call (arguments, function (modifier){
+    if(modifier in modifiers)
+      modifiers[modifier] = true;
+    else
+      throw new Error ("Invalid modifier name");
+  });
+  return this;
+};
+
+module.exports.modifiers = modifiers;

--- a/test/parse.js
+++ b/test/parse.js
@@ -592,6 +592,21 @@ var tests = {
       
       done ();
     });
+  },
+  "modifier: stable number coercion": function (done){
+    properties.with ('MOD_STABLE_NUMBER_COERCION')
+      .parse ("a1 1\na2 01\na3 10000000000001.0000000000001\na4 +1", function (error, p){
+      assert.ifError (error);
+
+      assert.deepStrictEqual (p, {
+        a1: 1,
+        a2: '01',
+        a3: '10000000000001.0000000000001',
+        a4: "+1"
+      });
+
+      done ();
+    });
   }
 };
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -598,12 +598,10 @@ var tests = {
       .parse ("a1 1\na2 01\na3 10000000000001.0000000000001\na4 +1", function (error, p){
       assert.ifError (error);
 
-      assert.deepStrictEqual (p, {
-        a1: 1,
-        a2: '01',
-        a3: '10000000000001.0000000000001',
-        a4: "+1"
-      });
+      assert.strictEqual (p.a1, 1);
+      assert.strictEqual (p.a2, "01");
+      assert.strictEqual (p.a3, "10000000000001.0000000000001");
+      assert.strictEqual (p.a4, "+1");
 
       done ();
     });


### PR DESCRIPTION
I couldn't find anything concrete about java.util.Properties and type conversion - maybe doesn't translate well as this change request is arguably more useful for Javascript projects than the current behaviour.  However the point is moot as there are too many dependencies / downloads on the NPM package to be making breaking changes.  With that in mind I'm suggesting a `with` function that allows for modification to the context via additional flags without altering the existing logic.