### PR TITLE
support keeping escaped line breaks with spaces following them

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -242,7 +242,12 @@ module.exports = function (data, options, handlers, control){
         if (!escapingUnicode){
           escape = false;
         }
-        skipSpace = true;
+        if (options.keepEscapedLineBreaks) {
+          value += '\\\n';
+          skipSpace = false;
+        } else {
+          skipSpace = true;
+        }
         multiLine = true;
       }else{
         if (isSectionLine){

--- a/test/parse.js
+++ b/test/parse.js
@@ -81,6 +81,29 @@ var tests = {
       done ();
     });
   },
+  "parse (keep no escaped line breaks)": function (done) {
+    properties.parse ("a = b\\\n  c\\\n d", function (error, p){
+      assert.ifError (error);
+
+      assert.deepEqual (p, {
+        a: "bcd",
+      });
+
+      done ();
+    });
+  },
+  "parse (keep escaped line breaks)": function (done) {
+    var options = { keepEscapedLineBreaks: true };
+    properties.parse ("a = b\\\n  c\\\n d", options, function (error, p){
+      assert.ifError (error);
+
+      assert.deepEqual (p, {
+        a: "b\\\n  c\\\n d",
+      });
+
+      done ();
+    });
+  },
   "reviver": function (done){
     var options = {
       reviver: function (key, value){


### PR DESCRIPTION
It is an important option to keep anything preserved like these escaped line breaks.